### PR TITLE
Calculating diagonal size based on actual container size

### DIFF
--- a/SuperParticles.js
+++ b/SuperParticles.js
@@ -317,7 +317,7 @@ window.SuperParticles = window.SuperParticles || class SuperParticles {
         if (this.cfg.particles.keepRelativePositionOnResize) {
             const oldWidth = this.app.renderer.screen.width
             const oldHeight = this.app.renderer.screen.height
-            this.diagonalSize = this._getDistance({x:0,y:0},{x:this.app.renderer.screen.width,y:this.app.renderer.screen.height})
+            this.diagonalSize = this._getDistance({x:0,y:0},{x:width,y:height})
             for (const particle of this.particles) {
                 particle.x = particle.x*width/oldWidth
                 particle.y = particle.y*height/oldHeight


### PR DESCRIPTION
I encountered problems where `app.renderer.screen` was reporting `800` x `600` instead of proper dimensions.
On first `resize` event it would report the correct dimensions, resulting in a big change in `diagonalSize`, so the line distance was always very messed up either for die initial value or for the proper (after resize) value.

This solves it by using the actual container dimensions to calculate the `diagonalSize`.